### PR TITLE
Add opt out buttons and track opt out reason

### DIFF
--- a/src/components/OptOut.js
+++ b/src/components/OptOut.js
@@ -4,11 +4,14 @@ import FormAlert from "./FormAlert";
 import Button from "react-bootstrap/Button";
 import Spinner from "react-bootstrap/Spinner";
 import analytics from "./../util/analytics.js";
+import { updateUser } from "./../util/db";
+import { useAuth } from './../util/auth.js';
 
 function OptOut(props) {
   const [pending, setPending] = useState(false);
-
   const [formAlert, setFormAlert] = useState(null);
+
+  const auth = useAuth();
 
   const RECEIVED_DOSE_OPT_OUT_REASON = "received_dose";
   const OTHER_OPT_OUT_REASON = "other";
@@ -26,24 +29,51 @@ function OptOut(props) {
 
     let optOutReason = event.target[0].value;
     if (!OPT_OUT_REASONS.includes(optOutReason)) {
-      setFormAlert({
-        type: "error",
-        message: "Please select a reason for opting out",
-      });
+      setFormErrorMessage("Please select a reason for opting out");
       setPending(false);
       return;
     }
 
-    // Opt user out of notifications
-    // TODO
+    if (auth.user.optout) {
+      setOptOutSuccessMessage("You have already opted out of notifications.")
+      setPending(false);
+      return;
+    }
 
-    // Track opt out reason
-    analytics.track('optOut', {
-      reason: optOutReason
+    optOutUser()
+      .then(() => {
+        trackOptOutReason(optOutReason);
+        setOptOutSuccessMessage("You have successfully opted out of notifications.");
+      })
+      .catch((error) => {
+        setFormErrorMessage("There was an error updating your preferences. Please try again.");
+      })
+      .finally(() => {
+        setPending(false);
+      });
+  }
+
+  const optOutUser = async () => {
+    let data = { optout: true };
+    await updateUser(auth.user.uid, data);
+  }
+
+  const setFormErrorMessage = (message) => {
+    setFormAlert({
+      type: "error",
+      message: message,
     });
+  }
 
-    // Hide pending indicator
-    setPending(false);
+  const setOptOutSuccessMessage = (message) => {
+    setFormAlert({
+      type: "success",
+      message: message,
+    });
+  }
+
+  const trackOptOutReason = (optOutReason) => {
+    analytics.track('optOut', { reason: optOutReason });
   }
 
   return (

--- a/src/components/OptOut.js
+++ b/src/components/OptOut.js
@@ -1,200 +1,91 @@
 import React, { useState } from "react";
 import Form from "react-bootstrap/Form";
 import FormAlert from "./FormAlert";
-import FormField from "./FormField";
 import Button from "react-bootstrap/Button";
 import Spinner from "react-bootstrap/Spinner";
-import { useAuth } from "./../util/auth.js";
-import { useForm } from "react-hook-form";
-import sendAccountActivatedMessage from "./../util/twilio"
+import analytics from "./../util/analytics.js";
 
 function OptOut(props) {
-  const auth = useAuth();
   const [pending, setPending] = useState(false);
 
-  const { register, handleSubmit, errors } = useForm();
   const [formAlert, setFormAlert] = useState(null);
 
+  const RECEIVED_DOSE_OPT_OUT_REASON = "received_dose";
+  const OTHER_OPT_OUT_REASON = "other";
+  const OPT_OUT_REASONS = [
+    RECEIVED_DOSE_OPT_OUT_REASON,
+    OTHER_OPT_OUT_REASON
+  ];
 
-  // State to control whether we show a re-authentication flow
-  // Required by some security sensitive actions, such as changing password.
-  const [reauthState, setReauthState] = useState({
-    show: false,
-  });
+  const processOptOut = async (event) => {
+    event.preventDefault();
+    setFormAlert(null);
 
-  // Handle status of type "success", "error", or "requires-recent-login"
-  // We don't treat "requires-recent-login" as an error as we handle it
-  // gracefully by taking the user through a re-authentication flow.
-  const onStatus = ({ type, message, callback }) => {
-    if (type === "requires-recent-login") {
-      // First clear any existing message
-      setFormAlert(null);
-      // Then update state to show re-authentication modal
-      setReauthState({
-        show: true,
-        // Failed action to try again after reauth
-        callback: callback,
-      });
-    } else {
-      // Display message to user (type is success or error)
-      setFormAlert({
-        type: type,
-        message: message,
-      });
-    }
-  };
-
-  const onSubmit = async (data) => {
     // Show pending indicator
     setPending(true);
-    let passVerificationChecks = true;
 
-    // verify phone number is Canadian
-    let phoneNumberRegex = /^((([0-9]{1})*[- .(]*([0-9]{3})[- .)]*[0-9]{3}[- .]*[0-9]{4})+)*$/
-
-    // verify postal code
-    let postalCodeRegex = /^([ABCEGHJKLMNPRSTVXY][0-9][A-Z] [0-9][A-Z][0-9])*$/;
-
-    passVerificationChecks = phoneNumberRegex.test(data.phone) && postalCodeRegex.test(data.postalcode.toUpperCase());
-
-    if (!passVerificationChecks) {
-      onStatus({
+    let optOutReason = event.target[0].value;
+    if (!OPT_OUT_REASONS.includes(optOutReason)) {
+      setFormAlert({
         type: "error",
-        message: "Phone Number or Postal Code is not valid",
+        message: "Please select a reason for opting out",
       });
       setPending(false);
       return;
     }
 
-    if (props.newUser) {
-      sendAccountActivatedMessage({receiver: data.phone});
-    }
+    // Opt user out of notifications
+    // TODO
 
-    return auth
-      .updateProfile(data)
-      .then(() => {
-        // Set success status
-        onStatus({
-          type: "success",
-          message: "Your profile has been updated",
-        });
-      })
-      .catch((error) => {
-        if (error.code === "auth/requires-recent-login") {
-          onStatus({
-            type: "requires-recent-login",
-            // Resubmit after reauth flow
-            callback: () => onSubmit(data),
-          });
-        } else {
-          // Set error status
-          onStatus({
-            type: "error",
-            message: error.message,
-          });
-        }
-      })
-      .finally(() => {
-        // Hide pending indicator
-        setPending(false);
-      });
-  };
+    // Track opt out reason
+    analytics.track('optOut', {
+      reason: optOutReason
+    });
+
+    // Hide pending indicator
+    setPending(false);
+  }
 
   return (
-    <p>Opt out of notifications</p>
-    // <Form onSubmit={handleSubmit(onSubmit)}>
+    <div>
+      <p>Opt out of notifications</p>
 
-    //   {formAlert && (
-    //     <FormAlert type={formAlert.type} message={formAlert.message} />
-    //   )}
-    
-    //   <Form.Group controlId="formName">
-    //     <FormField
-    //       name="name"
-    //       type="text"
-    //       label="Name"
-    //       defaultValue={auth.user.name}
-    //       placeholder="Name"
-    //       error={errors.name}
-    //       size="lg"
-    //       inputRef={register({
-    //         required: "Please enter your name",
-    //       })}
-    //     />
-    //   </Form.Group>
-    //   <Form.Group controlId="formPhone">
-    //     <FormField
-    //       name="phone"
-    //       type="text"
-    //       label="Phone Number (i.e. 4161231234)"
-    //       defaultValue={auth.user.phone}
-    //       placeholder="i.e. 4161231234"
-    //       error={errors.phone}
-    //       size="lg"
-    //       inputRef={register({
-    //         required: "Please enter your phone number as '4161231234' format",
-    //       })}
-    //     />
-    //   </Form.Group>
-    //   <Form.Group controlId="formPostalCode">
-    //     <FormField
-    //       name="postalcode"
-    //       type="text"
-    //       label="Postal Code (i.e. A1A 1A1)"
-    //       defaultValue={auth.user.postalcode}
-    //       placeholder="i.e. A1A 1A1"
-    //       error={errors.postalcode}
-    //       size="lg"
-    //       inputRef={register({
-    //         required: "Please enter your Postal Code in 'A1A 1A1' format",
-    //       })}
-    //     />
-    //   </Form.Group>
-    //   <Form.Group controlId="formProvince">
-    //     <FormField
-    //       name="province"
-    //       type="select"
-    //       options={[
-    //         "AB",
-    //         "BC",
-    //         "MB",
-    //         "NB",
-    //         "NL",
-    //         "NT",
-    //         "NS",
-    //         "NU",
-    //         "ON",
-    //         "PE",
-    //         "QC",
-    //         "SK",
-    //         "YT",
-    //       ]}
-    //       label="Province"
-    //       defaultValue={auth.user.province}
-    //       placeholder="Province"
-    //       error={errors.province}
-    //       size="lg"
-    //       inputRef={register({
-    //         required: "Please enter your Province",
-    //       })}
-    //     />
-    //   </Form.Group>
-    //   <Button type="submit" size="lg" disabled={pending}>
-    //     <span>Save</span>
+      <Form onSubmit={processOptOut}>
 
-    //     {pending && (
-    //       <Spinner
-    //         animation="border"
-    //         size="sm"
-    //         role="status"
-    //         aria-hidden={true}
-    //         className="ml-2 align-baseline"
-    //       >
-    //         <span className="sr-only">Sending...</span>
-    //       </Spinner>
-    //     )}
-    //   </Button>
-    // </Form>
+        {formAlert && (
+          <FormAlert type={formAlert.type} message={formAlert.message} />
+        )}
+
+        <Form.Group controlId="optOutReason">
+          <Form.Label>Opt out reason:</Form.Label>
+          <Form.Control
+            as="select"
+            name="optOutReason"
+            defaultValue="Select a reason"
+          >
+            <option disabled>Select a reason</option>
+            <option value={RECEIVED_DOSE_OPT_OUT_REASON}>Received vaccine dose or appointment</option>
+            <option value={OTHER_OPT_OUT_REASON}>Other</option>
+          </Form.Control>
+        </Form.Group>
+
+        <Button type="submit" disabled={pending}>
+          <span>Opt out</span>
+
+          {pending && (
+            <Spinner
+              animation="border"
+              size="sm"
+              role="status"
+              aria-hidden={true}
+              className="ml-2 align-baseline"
+            >
+            <span className="sr-only">Updating...</span>
+            </Spinner>
+          )}
+        </Button>
+      </Form>
+    </div>
   );
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8861750/115131985-69131300-9fca-11eb-9881-75c8e5cd5482.png)

Currently only tracks the opt our reason (either `received_dose` or `other`), and updates the user's settings.

It also requires the user to select an opt out reason (should we allow opt out with no reason selected?)