### PR TITLE
updated eligibility and age groups

### DIFF
--- a/src/components/formConstants.js
+++ b/src/components/formConstants.js
@@ -1,5 +1,15 @@
 
-const ageGroups = ["18-49", "50-59", "60-79", "80+"]
+const ageGroups = [
+  "18-23",
+  "24-29",
+  "30-35",
+  "36-40",
+  "41-49",
+  "50-59", 
+  "60-79", 
+  "80+"
+]
+
 const eligibilityGroups = [
   "Faith leaders at higher risk of COVID-19 exposure (e.g. end-of-life care, care of deceased, home visits, care in health care and vulnerable settings)",
   "Health-care workers",

--- a/src/components/formConstants.js
+++ b/src/components/formConstants.js
@@ -1,6 +1,14 @@
 
 const ageGroups = ["18-49", "50-59", "60-79", "80+"]
-const eligibilityGroups = ["Congregate living for seniors", "Health care workers", "Adults in First Nations, Métis and Inuit populations", "Adult chronic home care recipients", "High-risk congregate settings", "Individuals with high-risk chronic conditions and their caregivers"]
+const eligibilityGroups = [
+  "Faith leaders at higher risk of COVID-19 exposure (e.g. end-of-life care, care of deceased, home visits, care in health care and vulnerable settings)",
+  "Health-care workers",
+  "THose who work or live in a high-risk congregate living setting",
+  "Essential caregivers to a person with a high risk condition",
+  "Congregate living for seniors", 
+  "Adults in First Nations, Métis and Inuit populations", 
+  "Adult chronic home care recipients"
+]
 const provinces = ["AB", "BC", "MB", "NB", "NL", "NT", "NS", "NU", "ON", "PE", "QC", "SK", "YT"]
 const provincesWAll = ["AB", "BC", "MB", "NB", "NL", "NT", "NS", "NU", "ON", "PE", "QC", "SK", "YT", "All"]
 


### PR DESCRIPTION
- the age groups i selected start with 5 year increments, and then are organized based on the groups that the vaccine is already available to and Astrazeneca age restrictions.